### PR TITLE
feat(workflows): add annotation type

### DIFF
--- a/.github/workflows/buildah-build-push-workflow.yaml
+++ b/.github/workflows/buildah-build-push-workflow.yaml
@@ -136,10 +136,12 @@ jobs:
 
             if [ -n "${OCI_ANNOTATIONS:-}" ]; then
               # BuildKit-style: [type:]key=value or key=value (default: index)
-              # Types: index, manifest-descriptor (comma-separated for both)
+              # Types: index, manifest, manifest-descriptor. Platform qualifier: type[os/arch]
+              # See: https://docs.docker.com/reference/cli/docker/buildx/build/#annotation
               index_args=()
-              descriptor_args=()
-              digests=($(buildah manifest inspect "${manifest}" | jq -r '.manifests[].digest'))
+              descriptor_anns=()
+              descriptor_platforms=()
+              mapfile -t manifest_entries < <(buildah manifest inspect "${manifest}" | jq -r '.manifests[] | "\(.digest)|\(.platform.os)/\(.platform.architecture)"')
 
               while IFS= read -r raw_line; do
                 raw_line="${raw_line%$'\r'}"
@@ -162,19 +164,34 @@ jobs:
                 fi
 
                 if [[ "$key_part" == *":"* ]]; then
-                  types="${key_part%%:*}"
+                  types_part="${key_part%%:*}"
                   ann="${key_part#*:}=${val}"
                 else
-                  types="index"
+                  types_part="index"
                   ann="${key_part}=${val}"
                 fi
 
-                IFS=',' read -ra TYPES <<< "$types"
+                IFS=',' read -ra TYPES <<< "$types_part"
                 for t in "${TYPES[@]}"; do
                   t="${t// /}"
+                  platform_filter=""
+                  if [[ "$t" =~ ^([a-z-]+)\[([^]]+)\]$ ]]; then
+                    platform_filter="${BASH_REMATCH[2]}"
+                    t="${BASH_REMATCH[1]}"
+                  fi
+
                   case "$t" in
-                    index) index_args+=(--annotation "${ann}") ;;
-                    manifest-descriptor) descriptor_args+=(--annotation "${ann}") ;;
+                    index)
+                      if [[ -n "$platform_filter" ]]; then
+                        echo "Platform qualifier not supported for index, skipping"
+                        continue
+                      fi
+                      index_args+=(--annotation "${ann}")
+                      ;;
+                    manifest|manifest-descriptor)
+                      descriptor_anns+=("${ann}")
+                      descriptor_platforms+=("${platform_filter}")
+                      ;;
                     *) echo "Unknown annotation type '$t', skipping" ;;
                   esac
                 done
@@ -183,11 +200,21 @@ jobs:
               if [ ${#index_args[@]} -gt 0 ]; then
                 buildah manifest annotate --index "${index_args[@]}" "${manifest}"
               fi
-              if [ ${#descriptor_args[@]} -gt 0 ]; then
-                for digest in "${digests[@]}"; do
-                  buildah manifest annotate "${descriptor_args[@]}" "${manifest}" "$digest"
+
+              for entry in "${manifest_entries[@]}"; do
+                digest="${entry%%|*}"
+                platform="${entry#*|}"
+                annotate_args=()
+                for i in "${!descriptor_anns[@]}"; do
+                  filter="${descriptor_platforms[i]}"
+                  if [[ -z "$filter" || "$filter" == "$platform" ]]; then
+                    annotate_args+=(--annotation "${descriptor_anns[i]}")
+                  fi
                 done
-              fi
+                if [ ${#annotate_args[@]} -gt 0 ]; then
+                  buildah manifest annotate "${annotate_args[@]}" "${manifest}" "$digest"
+                fi
+              done
             fi
 
             buildah manifest push --all "${manifest}"

--- a/.github/workflows/buildah-build-push-workflow.yaml
+++ b/.github/workflows/buildah-build-push-workflow.yaml
@@ -135,38 +135,59 @@ jobs:
             buildah manifest add "${manifest}" "docker://${REGISTRY}/${IMAGE}:${tag}-arm64"
 
             if [ -n "${OCI_ANNOTATIONS:-}" ]; then
-              # buildah manifest annotate requires digest, not docker:// URL.
+              # BuildKit-style: [type:]key=value or key=value (default: index)
+              # Types: index, manifest-descriptor (comma-separated for both)
+              index_args=()
+              descriptor_args=()
               digests=($(buildah manifest inspect "${manifest}" | jq -r '.manifests[].digest'))
 
-              for digest in "${digests[@]}"; do
-                annotate_args=()
-                while IFS= read -r raw_line; do
-                  raw_line="${raw_line%$'\r'}"
-                  raw_line="${raw_line#"${raw_line%%[![:space:]]*}"}"
-                  raw_line="${raw_line%"${raw_line##*[![:space:]]}"}"
-                  [ -z "$raw_line" ] && continue
+              while IFS= read -r raw_line; do
+                raw_line="${raw_line%$'\r'}"
+                raw_line="${raw_line#"${raw_line%%[![:space:]]*}"}"
+                raw_line="${raw_line%"${raw_line##*[![:space:]]}"}"
+                [ -z "$raw_line" ] && continue
 
-                  if [[ "$raw_line" != *"="* ]]; then
-                    echo "Skipping invalid annotation line (missing '='): $raw_line"
-                    continue
-                  fi
-
-                  key="${raw_line%%=*}"
-                  val="${raw_line#*=}"
-
-                  if [[ "$val" =~ ^\'(.*)\'$ ]]; then
-                    val="${BASH_REMATCH[1]}"
-                  elif [[ "$val" =~ ^\"(.*)\"$ ]]; then
-                    val="${BASH_REMATCH[1]}"
-                  fi
-
-                  annotate_args+=(--annotation "${key}=${val}")
-                done < <(printf '%s\n' "$OCI_ANNOTATIONS")
-
-                if [ ${#annotate_args[@]} -gt 0 ]; then
-                  buildah manifest annotate "${annotate_args[@]}" "${manifest}" "$digest"
+                if [[ "$raw_line" != *"="* ]]; then
+                  echo "Skipping invalid annotation line (missing '='): $raw_line"
+                  continue
                 fi
-              done
+
+                key_part="${raw_line%%=*}"
+                val="${raw_line#*=}"
+
+                if [[ "$val" =~ ^\'(.*)\'$ ]]; then
+                  val="${BASH_REMATCH[1]}"
+                elif [[ "$val" =~ ^\"(.*)\"$ ]]; then
+                  val="${BASH_REMATCH[1]}"
+                fi
+
+                if [[ "$key_part" == *":"* ]]; then
+                  types="${key_part%%:*}"
+                  ann="${key_part#*:}=${val}"
+                else
+                  types="index"
+                  ann="${key_part}=${val}"
+                fi
+
+                IFS=',' read -ra TYPES <<< "$types"
+                for t in "${TYPES[@]}"; do
+                  t="${t// /}"
+                  case "$t" in
+                    index) index_args+=(--annotation "${ann}") ;;
+                    manifest-descriptor) descriptor_args+=(--annotation "${ann}") ;;
+                    *) echo "Unknown annotation type '$t', skipping" ;;
+                  esac
+                done
+              done < <(printf '%s\n' "$OCI_ANNOTATIONS")
+
+              if [ ${#index_args[@]} -gt 0 ]; then
+                buildah manifest annotate --index "${index_args[@]}" "${manifest}"
+              fi
+              if [ ${#descriptor_args[@]} -gt 0 ]; then
+                for digest in "${digests[@]}"; do
+                  buildah manifest annotate "${descriptor_args[@]}" "${manifest}" "$digest"
+                done
+              fi
             fi
 
             buildah manifest push --all "${manifest}"

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ jobs:
 | `containerfiles` | no    | `./Containerfile` | Path(s) to Containerfile/Dockerfile   |
 | `context`     | no       | `.`               | Build context path                   |
 | `labels`      | no       | `""`              | Image labels (newline-separated `key=value`) |
-| `annotations` | no       | `""`              | OCI image annotations (newline-separated `key=value`) |
+| `annotations` | no       | `""`              | OCI annotations (newline-separated). Format: `[type:]key=value`. Types: `index`, `manifest-descriptor`. Default: `index`. |
 | `registry`    | yes      | —                 | Registry host (e.g. `ghcr.io`)       |
 | `push`        | no       | `true`            | Push to registry; `false` = build only |
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ jobs:
 | `containerfiles` | no    | `./Containerfile` | Path(s) to Containerfile/Dockerfile   |
 | `context`     | no       | `.`               | Build context path                   |
 | `labels`      | no       | `""`              | Image labels (newline-separated `key=value`) |
-| `annotations` | no       | `""`              | OCI annotations (newline-separated). Format: `[type:]key=value`. Types: `index`, `manifest-descriptor`. Default: `index`. |
+| `annotations` | no       | `""`              | OCI annotations (newline-separated). Format: `[type:]key=value`. Types: `index`, `manifest`, `manifest-descriptor`. Platform qualifier: `manifest[linux/amd64]:key=value`. Default: `index`. |
 | `registry`    | yes      | —                 | Registry host (e.g. `ghcr.io`)       |
 | `push`        | no       | `true`            | Push to registry; `false` = build only |
 


### PR DESCRIPTION
> [!NOTE]
> In Buildah `1.33` there’s no built-in way to annotate the index itself. The only command that can do that is `buildah manifest annotate --index`, which was added in `1.35`.

This PR adds ability to specify annotation type.